### PR TITLE
Minor tweak to logo layout

### DIFF
--- a/src/Logo.jsx
+++ b/src/Logo.jsx
@@ -15,7 +15,7 @@ const Logo = () => (
         transform="translate(-9 -11)"
       >
         <text fill="#FF877C" font-family="AndaleMono, Andale Mono">
-          <tspan x="0" y="54">
+          <tspan x="10" y="54">
             random{" "}
           </tspan>{" "}
           <tspan
@@ -25,7 +25,7 @@ const Logo = () => (
           >
             {" "}
           </tspan>{" "}
-          <tspan x="312.041" y="54">
+          <tspan x="352.041" y="54">
             generator
           </tspan>
         </text>


### PR DESCRIPTION
Text was wonky in chrome (windows). Went from:

![image](https://user-images.githubusercontent.com/90380/56828959-7f00f980-6830-11e9-81bf-da564ce95905.png)

to

![image](https://user-images.githubusercontent.com/90380/56828939-71e40a80-6830-11e9-99e1-7789541f3d70.png)
